### PR TITLE
Adiciona a funcionalidade de GET para trilhas cadastradas ao usuário

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -104,9 +104,30 @@ const SignToTrack = async (req, res) => {
     }
 };
 
+const GetUserTracks = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const tracks = await knex
+            .select("*")
+            .from("tracks")
+            .join("user_track", function () {
+                this.on("tracks.id", "=", "track_id").onIn("user_id", id);
+            });
+        if (tracks.length < 1)
+            return res
+                .status(404)
+                .json({ message: "Nenhuma trilha cadastrada!" });
+        return res.status(200).send(tracks);
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ message: "Erro no servidor." });
+    }
+};
+
 module.exports = {
     SignUp,
     Login,
     UpdateUser,
     SignToTrack,
+    GetUserTracks,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,6 +6,7 @@ const {
     Login,
     UpdateUser,
     SignToTrack,
+    GetUserTracks,
 } = require("./controllers/users");
 const {
     AdminSignUp,
@@ -27,6 +28,7 @@ routes.post("/signup", validateUserData(userSignUpSchema), SignUp);
 routes.post("/login", Login);
 routes.post("/user/update", validateEmailUser, UpdateUser);
 routes.post("/user/sign_track/:track_id", SignToTrack);
+routes.get("/user/tracks/:id", GetUserTracks);
 routes.get("/tracks", GetTracks);
 routes.get("/:id/contents", GetContentsToTrack);
 routes.post("/admin/signup", validateAdminData(userSignUpSchema), AdminSignUp); //DEVELOPMENT ONLY


### PR DESCRIPTION
Foi adicionado o recurso para buscar as trilhas cadastradas ao usuário. Foi feita a validação para caso não exista uma trilha cadastrada. Foi feito teste com o Insomnia, com requisições para a rota em questão. No momento está sendo retornado as trilhas. A requisição do conteúdo devera ser feita com o id do usuário na URL.

> Modelo de requisição das trilhas:
```
http://localhost:3000/user/tracks/3
```

> Modelo de resposta das trilhas:
```
[
	{
		"id": 1,
		"name": "DEV",
		"status": "10",
		"user_id": 3,
		"track_id": 1
	},
	{
		"id": 2,
		"name": "UX",
		"status": "50",
		"user_id": 3,
		"track_id": 2
	}
]
```